### PR TITLE
PHP_CodeSniffer version 2

### DIFF
--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -14,8 +14,8 @@
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 
-if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === false) {
-    $error = 'Class PHP_CodeSniffer_CommentParser_ClassCommentParser not found';
+if (class_exists('PHP_CodeSniffer_Tokenizers_Comment', true) === false) {
+    $error = 'Class PHP_CodeSniffer_Tokenizers_Comment not found';
     throw new PHP_CodeSniffer_Exception($error);
 }
 

--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -66,31 +66,26 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
     }
 
     /**
-     * Process the return comment of this function comment.
-     *
-     * @param int $commentStart The position in the stack where the comment started.
-     * @param int $commentEnd   The position in the stack where the comment ended.
-     *
-     * @return void
+     * {@inheritdoc}
      */
-    protected function processReturn($commentStart, $commentEnd)
+    protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
-        if ($this->isInheritDoc()) {
+
+        if ($this->isInheritDoc($phpcsFile, $stackPtr)) {
             return;
         }
 
-        $tokens = $this->currentFile->getTokens();
-        $funcPtr = $this->currentFile->findNext(T_FUNCTION, $commentEnd);
+        $tokens = $phpcsFile->getTokens();
 
         // Only check for a return comment if a non-void return statement exists
-        if (isset($tokens[$funcPtr]['scope_opener'])) {
-            $start = $tokens[$funcPtr]['scope_opener'];
+        if (isset($tokens[$stackPtr]['scope_opener'])) {
+            $start = $tokens[$stackPtr]['scope_opener'];
 
             // iterate over all return statements of this function,
             // run the check on the first which is not only 'return;'
-            while ($returnToken = $this->currentFile->findNext(T_RETURN, $start, $tokens[$funcPtr]['scope_closer'])) {
+            while ($returnToken = $phpcsFile->findNext(T_RETURN, $start, $tokens[$stackPtr]['scope_closer'])) {
                 if ($this->isMatchingReturn($tokens, $returnToken)) {
-                    parent::processReturn($commentStart, $commentEnd);
+                    parent::processReturn($phpcsFile, $stackPtr, $commentStart);
                     break;
                 }
                 $start = $returnToken + 1;
@@ -102,30 +97,36 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
     /**
      * Is the comment an inheritdoc?
      *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     * 
      * @return boolean True if the comment is an inheritdoc
      */
-    protected function isInheritDoc ()
+    protected function isInheritDoc(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $content = $this->commentParser->getComment()->getContent();
+        $tokens = $phpcsFile->getTokens();
+
+        $start = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
+        $end = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
+
+        $content = $phpcsFile->getTokensAsString($start, ($end - $start));
 
         return preg_match('#{@inheritdoc}#i', $content) === 1;
     } // end isInheritDoc()
 
     /**
-     * Process the function parameter comments.
-     *
-     * @param int $commentStart The position in the stack where
-     *                          the comment started.
-     *
-     * @return void
+     * {@inheritdoc}
      */
-    protected function processParams($commentStart)
+    protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
-        if ($this->isInheritDoc()) {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($this->isInheritDoc($phpcsFile, $stackPtr)) {
             return;
         }
 
-        parent::processParams($commentStart);
+        parent::processParams($phpcsFile, $stackPtr, $commentStart);
     } // end processParams()
 
     /**
@@ -136,7 +137,7 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
      *
      * @return boolean True if the return does not return anything
      */
-    protected function isMatchingReturn ($tokens, $returnPos)
+    protected function isMatchingReturn($tokens, $returnPos)
     {
         do {
             $returnPos++;


### PR DESCRIPTION
makes this Symfony2 coding standard compatible with squidlab's PHP_CodeSniffer version 2
###### note:

the approach for dealing with the `{@inheritdoc}` comments is similar to the original approach in this repo. according to this discussion: https://github.com/squizlabs/PHP_CodeSniffer/pull/214 there might be a better solution for these kind of comments in a future version of PHP_CodeSniffer
