### PR TITLE
PEAR standard does not support inheritdoc

### DIFF
--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -66,7 +66,14 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
     }
 
     /**
-     * {@inheritdoc}
+     * Process the return comment of this function comment.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                  $stackPtr     The position of the current token
+     *                                           in the stack passed in $tokens.
+     * @param int                  $commentStart The position in the stack where the comment started.
+     *
+     * @return void
      */
     protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {
@@ -100,7 +107,7 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the current token
      *                                        in the stack passed in $tokens.
-     * 
+     *
      * @return boolean True if the comment is an inheritdoc
      */
     protected function isInheritDoc(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
@@ -116,7 +123,14 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
     } // end isInheritDoc()
 
     /**
-     * {@inheritdoc}
+     * Process the function parameter comments.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                  $stackPtr     The position of the current token
+     *                                           in the stack passed in $tokens.
+     * @param int                  $commentStart The position in the stack where the comment started.
+     *
+     * @return void
      */
     protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
     {


### PR DESCRIPTION
sorry, still had some uncommited changes in the phpcs 2 branch which fixed an issue where

``` bash
phpcs --ignore=*/tests/* --standard=PEAR . -n
```

(as stated in the contributing section of the readme.md) returned several codestyle issues as the phpcs + pear standard does not support  `{@inheritdoc}`

bit sloppy…
