### PR TITLE
Adding auto-fixes for "whitespace around binary operators" and "whitespace after commas in arrays"

### DIFF
--- a/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
@@ -61,9 +61,9 @@ class Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff
 
         if ($tokens[$stackPtr -1]['code'] !== T_WHITESPACE || $tokens[$stackPtr +1]['code'] !== T_WHITESPACE) {
             $fix = $phpcsFile->addFixableError(
-              'Add a single space around binary operators',
-              $stackPtr,
-              "Invalid"
+                'Add a single space around binary operators',
+                $stackPtr,
+                "Invalid"
             );
 
             if ($fix === true) {

--- a/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
@@ -60,11 +60,21 @@ class Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr -1]['code'] !== T_WHITESPACE || $tokens[$stackPtr +1]['code'] !== T_WHITESPACE) {
-            $phpcsFile->addError(
-                'Add a single space around binary operators',
-                $stackPtr,
-                'Invalid'
+            $fix = $phpcsFile->addFixableError(
+              'Add a single space around binary operators',
+              $stackPtr,
+              "Invalid"
             );
+
+            if ($fix === true) {
+                if ($tokens[$stackPtr -1]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->fixer->addContentBefore($stackPtr, " ");
+                }
+
+                if ($tokens[$stackPtr +1]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->fixer->addContent($stackPtr, " ");
+                }
+            }
         }
     }//end process()
 

--- a/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -64,11 +64,15 @@ class Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff implements PHP_CodeSniffer_Sn
         $line   = $tokens[$stackPtr]['line'];
 
         if ($tokens[$stackPtr + 1]['line'] === $line && $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
-            $phpcsFile->addError(
+            $fix = $phpcsFile->addFixableError(
                 'Add a single space after each comma delimiter',
                 $stackPtr,
                 'Invalid'
             );
+
+            if ($fix) {
+				$phpcsFile->fixer->addContent($stackPtr, " ");
+			}
         }
 
     }//end process()

--- a/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -71,8 +71,8 @@ class Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff implements PHP_CodeSniffer_Sn
             );
 
             if ($fix) {
-				$phpcsFile->fixer->addContent($stackPtr, " ");
-			}
+		$phpcsFile->fixer->addContent($stackPtr, " ");
+            }
         }
 
     }//end process()


### PR DESCRIPTION
... is there a policy on doing this?  I notice that these sniffs do not generally have auto-fixes.
