### PR TITLE
Move squizlabs/php_codesniffer dependency to dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "source": "https://github.com/escapestudios/Symfony2-coding-standard",
         "issues": "https://github.com/escapestudios/Symfony2-coding-standard/issues"
     },
-    "require": {
+    "require-dev": {
         "squizlabs/php_codesniffer": "~2.0"
     }
 }


### PR DESCRIPTION
Most of the time phpcs is installed with the .phar binary.

A coding standard like this one is generally installed globally with composer.

Require squizlabs/php_codesniffer package force user to download the whole phpcs package and dependencies and can add binary path conflicts.

Plus, this is quite obvious that a user need phpcs to get this plugin working.
