### PR TITLE
Add fixer for MultilineArrayCommaSniff

### DIFF
--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -86,7 +86,7 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
                     );
 
                     if ($fix === true) {
-                        $ptr = $phpcsFile->findPrevious([T_WHITESPACE, T_COMMENT], $closePtr-1, null, true);
+                        $ptr = $phpcsFile->findPrevious([T_WHITESPACE, T_COMMENT], $closePtr-1, $stackPtr, true);
 
                         $phpcsFile->fixer->addContent($ptr, ',');
                         $phpcsFile->fixer->endChangeset();

--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -86,7 +86,7 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
                     );
 
                     if ($fix === true) {
-                        $ptr = $phpcsFile->findPrevious([T_WHITESPACE, T_COMMENT], $closePtr-1, $stackPtr, true);
+                        $ptr = $phpcsFile->findPrevious(array(T_WHITESPACE, T_COMMENT), $closePtr-1, $stackPtr, true);
 
                         $phpcsFile->fixer->addContent($ptr, ',');
                         $phpcsFile->fixer->endChangeset();

--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -79,11 +79,19 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
                 if ($tokens[$lastComma]['code'] !== T_WHITESPACE
                     && $tokens[$lastComma]['code'] !== T_COMMENT
                 ) {
-                    $phpcsFile->addError(
+                    $fix = $phpcsFile->addFixableError(
                         'Add a comma after each item in a multi-line array',
                         $stackPtr,
                         'Invalid'
                     );
+
+                    if ($fix === true) {
+                        $ptr = $phpcsFile->findPrevious([T_WHITESPACE, T_COMMENT], $closePtr-1, null, true);
+
+                        $phpcsFile->fixer->addContent($ptr, ',');
+                        $phpcsFile->fixer->endChangeset();
+                    }
+
                     break;
                 }
             }


### PR DESCRIPTION
Add a comma after the last non-comment and non-whitespace token in an array.

Forgot I attempted this previously #20. It was never merged because it didn't work. This implementation was tested to fix arrays of variable content and format.