### PR TITLE
Check for extended interfaces in ValidClassNameSniff

### DIFF
--- a/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
@@ -58,7 +58,8 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
                 T_OPEN_TAG
             ),
             ($stackPtr - 1)
-        )) {
+        )
+        ) {
             return;
         }
 

--- a/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -129,9 +129,14 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff
              * Prefix abstract classes with Abstract.
              */
             if ('T_ABSTRACT' == $tokens[$stackPtr]['type']) {
+                // first check to make sure we aren't extending an interface
+                if ($phpcsFile->findPrevious(T_INTERFACE, $stackPtr)) {
+                    break;
+                }
+
                 $name = $phpcsFile->findNext(T_STRING, $stackPtr);
                 $function = $phpcsFile->findNext(T_FUNCTION, $stackPtr);
-                
+
                 // making sure we're not dealing with an abstract function
                 if ($name && (is_null($function)
                     || $name < $function)

--- a/Symfony2/Tests/NamingConventions/ValidClassNameUnitTest.inc
+++ b/Symfony2/Tests/NamingConventions/ValidClassNameUnitTest.inc
@@ -1,0 +1,33 @@
+<?php
+
+// Abstract Class Names
+
+abstract class BadAbstractClassName {}
+
+abstract class AbstractTest {}
+
+class BadTest extends AbstractTest {}
+
+// Trait Class Names
+
+trait BadTraitName {}
+
+trait GoodTrait {}
+
+// Interface Class Names
+
+interface BadInterfaceName {}
+
+interface GoodInterface {}
+
+interface BadInterfaceChild extends BadInterfaceName {}
+
+interface GoodChildInterface extends GoodInterface {}
+
+// Exception Class Names
+
+class BaseException {}
+
+class GoodChildException extends BaseException {}
+
+class BadExceptionChild extends BaseException {}

--- a/Symfony2/Tests/NamingConventions/ValidClassNameUnitTest.php
+++ b/Symfony2/Tests/NamingConventions/ValidClassNameUnitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@escapestudios.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+
+/**
+ * Unit test class for the ValidClassName sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@escapestudios.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/escapestudios/Symfony2-coding-standard
+ */
+class Symfony2_Tests_NamingConventions_ValidClassNameUnitTest
+    extends AbstractSniffUnitTest
+{
+    /**
+     * Returns the lines where errors should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getErrorList()
+    {
+        return array(
+            9 => 1,
+            13 => 1,
+            19 => 1,
+            23 => 1,
+            33 => 1,
+        );
+    }
+
+    /**
+     * Returns the lines where warnings should occur.
+     *
+     * The key of the array should represent the line number and the value
+     * should represent the number of errors that should occur on that line.
+     *
+     * @return array(int => int)
+     */
+    public function getWarningList()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
I ran into a problem when extending an interface so I added a check to see if the T_EXTENDS was for an interface. If so, it breaks out of the loop (because this should have already been checked by the T_INTERFACE on an earlier token).

I also created tests for all of the ValidClassName sniffs using the format of the other sniff tests, but I had problems getting the tests to run properly on my local machine (no tests were run when I executed the same command that is generated by the `build.xml` config).

Finally, I added a carriage return to `FunctionCommentSniff` to match the PEAR format (it threw an error when I ran PHPCS against the codebase).