### PR TITLE
ReturnOrThrowSniff doesn't handle Closures properly

### DIFF
--- a/Symfony/Sniffs/Formatting/ReturnOrThrowSniff.php
+++ b/Symfony/Sniffs/Formatting/ReturnOrThrowSniff.php
@@ -70,8 +70,8 @@ class ReturnOrThrowSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         $elem = $tokens[$stackPtr];
 
-        // find the function we're currently in and an if or case statement
-        $function = $phpcsFile->findPrevious(T_FUNCTION, $stackPtr);
+        // find the function/closure we're currently in and an if or case statement
+        $function = $phpcsFile->findPrevious([T_FUNCTION, T_CLOSURE], $stackPtr);
 
         if (false === $function) {
             return;

--- a/Symfony/Tests/Formatting/ReturnOrThrowUnitTest.inc
+++ b/Symfony/Tests/Formatting/ReturnOrThrowUnitTest.inc
@@ -16,3 +16,14 @@ function bar()
 
     return true;
 }
+
+function baz()
+{
+    if ($a == $b) {
+        $a = function () {
+            return false;
+        };
+    } else {
+        return true;
+    }
+}


### PR DESCRIPTION
When closure is defined, this sniff should handle code inside closure.