### PR TITLE
Add a conflict rule to enforce compatible PHPCS versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpcodesniffer-standard",
     "description": "CodeSniffer ruleset for the Symfony 2+ coding standard",
     "keywords": ["Symfony2", "Symfony", "coding standard", "phpcs"],
-    "homepage": "https://github.com/djoos/Symfony2-coding-standard",
+    "homepage": "https://github.com/djoos/Symfony-coding-standard",
     "license": "MIT",
     "authors": [
         {
@@ -22,11 +22,14 @@
     },
     "minimum-stability": "dev",
     "support" : {
-        "source": "https://github.com/escapestudios/Symfony2-coding-standard",
-        "issues": "https://github.com/escapestudios/Symfony2-coding-standard/issues"
+        "source": "https://github.com/djoos/Symfony-coding-standard",
+        "issues": "https://github.com/djoos/Symfony-coding-standard/issues"
     },
     "require-dev": {
-      "squizlabs/php_codesniffer": "3.*",
+        "squizlabs/php_codesniffer": "3.*",
         "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": "<3 || >=4"
     }
 }


### PR DESCRIPTION
When installing phpcs through composer, this allows enforcing the usage of compatible versions.

I also fixed a few references to the repo URL.