### PR TITLE
Add missing space between words

### DIFF
--- a/Symfony/Sniffs/Functions/ReturnTypeSniff.php
+++ b/Symfony/Sniffs/Functions/ReturnTypeSniff.php
@@ -81,7 +81,7 @@ class ReturnTypeSniff implements Sniff
                 }
 
                 if (T_SEMICOLON !== $tokens[$next + 1]['code']) {
-                    $error = 'Use return null; when a function explicitly';
+                    $error = 'Use return null; when a function explicitly ';
                     $error .= 'returns null values and use return; ';
                     $error .= 'when the function returns void values';
 


### PR DESCRIPTION
The ReturnTypeSniff is reporting errors with `explicitlyreturns` without a space between the two words.