### PR TITLE
Updated to ignore new lines for Squiz.Strings.ConcatenationSpacing.

### DIFF
--- a/Symfony/ruleset.xml
+++ b/Symfony/ruleset.xml
@@ -28,7 +28,11 @@
     <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.Scope.MemberVarScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
 
     <!-- We provide our own subclass of PEAR's ClassComment and FunctionComment sniff, but these will do: -->
     <rule ref="PEAR.Commenting.InlineComment"/>


### PR DESCRIPTION
closes GH-42
closes GH-44
closes GH-107