### PR TITLE
Add others allowed types for class creation

### DIFF
--- a/Symfony/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -72,6 +72,10 @@ class ObjectInstantiationSniff implements Sniff
             T_VARIABLE,
             T_STATIC,
             T_SELF,
+            T_DOUBLE_COLON,
+            T_OBJECT_OPERATOR,
+            T_OPEN_SQUARE_BRACKET,
+            T_CLOSE_SQUARE_BRACKET,
         );
 
         $object = $stackPtr;

--- a/Symfony/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -8,6 +8,10 @@ new $foo;
 new Foo ();
 new static;
 new self;
+new Foo::bar;
+new Foo::bar[true];
+new $foo->bar;
+new $foo->bar[true];
 
 // good
 new Foo();
@@ -29,3 +33,5 @@ new static($this->foo);
 new self();
 new self(true);
 new self($this->foo);
+new Foo::bar();
+new $foo->bar();

--- a/Symfony/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -50,6 +50,10 @@ class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
             8  => 1,
             9  => 1,
             10 => 1,
+            11 => 1,
+            12 => 1,
+            13 => 1,
+            14 => 1,
         );
     }
 


### PR DESCRIPTION
Double colon, object separator, etc...

closes GH-108