### PR TITLE
Support anonymous classes (#153), closes GH-153

### DIFF
--- a/Symfony/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/Symfony/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -51,6 +51,7 @@ class PropertyDeclarationSniff implements Sniff
     {
         return array(
             T_CLASS,
+            T_ANON_CLASS
         );
     }
 
@@ -81,10 +82,15 @@ class PropertyDeclarationSniff implements Sniff
         $wantedTokens = array(
             T_PUBLIC,
             T_PROTECTED,
-            T_PRIVATE
+            T_PRIVATE,
+            T_ANON_CLASS
         );
 
         while ($scope) {
+            if (T_ANON_CLASS === $tokens[$scope]['code']) {
+                $scope = $tokens[$scope]['scope_closer'];
+                continue;
+            }
             $scope = $phpcsFile->findNext(
                 $wantedTokens,
                 $scope + 1,

--- a/Symfony/Sniffs/Functions/ScopeOrderSniff.php
+++ b/Symfony/Sniffs/Functions/ScopeOrderSniff.php
@@ -52,6 +52,7 @@ class ScopeOrderSniff implements Sniff
         return array(
             T_CLASS,
             T_INTERFACE,
+            T_ANON_CLASS,
         );
     }
 
@@ -89,10 +90,18 @@ class ScopeOrderSniff implements Sniff
             }
 
             $function = $phpcsFile->findNext(
-                T_FUNCTION,
+                array(
+                    T_ANON_CLASS,
+                    T_FUNCTION,
+                ),
                 $function + 1,
                 $end
             );
+
+            if (T_ANON_CLASS === $tokens[$function]['code']) {
+                $function = $tokens[$function]['scope_closer'];
+                continue;
+            }
 
             if (isset($tokens[$function]['parenthesis_opener'])) {
                 $scope = $phpcsFile->findPrevious($scopes, $function -1, $stackPtr);

--- a/Symfony/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -81,6 +81,17 @@ class ObjectInstantiationSniff implements Sniff
         $object = $stackPtr;
         $line   = $tokens[$object]['line'];
 
+        if (T_ANON_CLASS === $tokens[$object + 2]['code']) {
+            if ($tokens[$object + 3]['code'] !== T_OPEN_PARENTHESIS) {
+                $phpcsFile->addError(
+                    'Use parentheses when instantiating classes',
+                    $stackPtr,
+                    'Invalid'
+                );
+            }
+            return;
+        }
+
         while ($object && $tokens[$object]['line'] === $line) {
             $object = $phpcsFile->findNext($allowed, $object + 1);
 

--- a/Symfony/Tests/Classes/PropertyDeclarationUnitTest.inc
+++ b/Symfony/Tests/Classes/PropertyDeclarationUnitTest.inc
@@ -8,3 +8,21 @@ class Foo
 
     private $bar;
 }
+new class()
+{
+    public function __construct()
+    {
+    }
+
+    private $property;
+};
+class Factory
+{
+    public function createObject()
+    {
+        return new class()
+        {
+            private $property;
+        };
+    }
+}

--- a/Symfony/Tests/Classes/PropertyDeclarationUnitTest.php
+++ b/Symfony/Tests/Classes/PropertyDeclarationUnitTest.php
@@ -43,7 +43,8 @@ class PropertyDeclarationUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return array(
-            9 => 1,
+            9  => 1,
+            17 => 1,
         );
     }
 

--- a/Symfony/Tests/Functions/ScopeOrderUnitTest.inc
+++ b/Symfony/Tests/Functions/ScopeOrderUnitTest.inc
@@ -8,3 +8,22 @@ class Foo
 
     public function qux(){}
 }
+new class()
+{
+    private function bar(){}
+
+    protected function baz(){}
+
+    public function qux(){}
+};
+class Factory
+{
+    private function createObject()
+    {
+        return new class()
+        {
+            public function foo(){}
+        };
+    }
+}
+

--- a/Symfony/Tests/Functions/ScopeOrderUnitTest.php
+++ b/Symfony/Tests/Functions/ScopeOrderUnitTest.php
@@ -43,8 +43,10 @@ class ScopeOrderUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return array(
-            7 => 1,
-            9 => 1,
+            7  => 1,
+            9  => 1,
+            15 => 1,
+            17 => 1,
         );
     }
 

--- a/Symfony/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -12,6 +12,7 @@ new Foo::bar;
 new Foo::bar[true];
 new $foo->bar;
 new $foo->bar[true];
+new class {};
 
 // good
 new Foo();
@@ -35,3 +36,4 @@ new self(true);
 new self($this->foo);
 new Foo::bar();
 new $foo->bar();
+new class() implements AnyInterface {};

--- a/Symfony/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -54,6 +54,7 @@ class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
             12 => 1,
             13 => 1,
             14 => 1,
+            15 => 1,
         );
     }
 


### PR DESCRIPTION
Adds support for anonymous classes.
There is currently a proplem with PHP < 7: Since anonymous classes where added in PHP 7, running these Sniffs now generates a `Notice` due to the missing constant `T_ANON_CLASS`.

I'm unsure how to handle this: Ignore it, check for PHP-Versions < 7 or require PHP > 7.