### PR TITLE
Fixed ReturnTypeSniff when `return_type_token` does not exist

### DIFF
--- a/Symfony/Sniffs/Functions/ReturnTypeSniff.php
+++ b/Symfony/Sniffs/Functions/ReturnTypeSniff.php
@@ -59,7 +59,7 @@ class ReturnTypeSniff implements Sniff
 
         $methodProperties = $phpcsFile->getMethodProperties($stackPtr);
 
-        $type = $methodProperties['return_type_token'];
+        $type = array_key_exists('return_type_token', $methodProperties) ? $methodProperties['return_type_token'] : false;
 
         if (false === $type || 'void' !== strtolower($tokens[$type]['content'])) {
             return;


### PR DESCRIPTION
Fixed ReturnTypeSniff when `return_type_token` does not exist in $methodProperties.

I don't know how is this broken on my machine and this PR is the only way I could make it work.
https://i.imgur.com/cNGHc9b.png