### PR TITLE
Whitespace/AssignmentSpacing: make the error auto-fixable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ php:
     - 7.3 # security support until 06/12/2021
     - nightly
 
+addons:
+  apt:
+    packages:
+      ant
+
 before_script:
   - stable='^[0-9\.]+$'; if [[ "$TRAVIS_PHP_VERSION" =~ $stable ]]; then phpenv config-rm xdebug.ini; fi
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - phpunit --version
 
 script:
     - ant test -Dcomposer.path=composer

--- a/Symfony/Sniffs/Whitespace/AssignmentSpacingSniff.php
+++ b/Symfony/Sniffs/Whitespace/AssignmentSpacingSniff.php
@@ -70,11 +70,24 @@ class AssignmentSpacingSniff implements Sniff
             || $tokens[$stackPtr + 1]['code'] !== T_WHITESPACE)
             && $tokens[$stackPtr - 1]['content'] !== 'strict_types'
         ) {
-            $phpcsFile->addError(
+            $fix = $phpcsFile->addFixableError(
                 'Add a single space around assignment operators',
                 $stackPtr,
                 'Invalid'
             );
+
+            if ($fix === true) {
+                $replacement = $tokens[$stackPtr]['content'];
+                if ($tokens[$stackPtr - 1]['code'] !== T_WHITESPACE) {
+                    $replacement = ' '.$replacement;
+                }
+
+                if ($tokens[$stackPtr + 1]['code'] !== T_WHITESPACE) {
+                    $replacement .= ' ';
+                }
+
+                $phpcsFile->fixer->replaceToken($stackPtr, $replacement);
+            }
         }
     }
 }

--- a/Symfony/Tests/Whitespace/AssignmentSpacingUnitTest.inc.fixed
+++ b/Symfony/Tests/Whitespace/AssignmentSpacingUnitTest.inc.fixed
@@ -1,0 +1,8 @@
+<?php strict_types=1
+
+$a = 'foo';
+
+$b = 'foo';
+$c = 'foo';
+
+$d = 'bar';


### PR DESCRIPTION
Not sure if the non-autofixable was intentional, but it seemed like an easy sniff to enable auto-fixing for.

Includes `.fixed` file to test the fixer.