### PR TITLE
infinite loop fix

### DIFF
--- a/Symfony/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Symfony/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -109,11 +109,12 @@ class ValidClassNameSniff implements Sniff
              */
             if ('T_EXTENDS' === $tokens[$stackPtr]['type']) {
                 $extend = $phpcsFile->findNext(T_STRING, $stackPtr);
+                $class = $phpcsFile->findPrevious(T_CLASS, $stackPtr);
 
                 if ($extend
+                    && false !== $class
                     && substr($tokens[$extend]['content'], -9) === 'Exception'
                 ) {
-                    $class = $phpcsFile->findPrevious(T_CLASS, $stackPtr);
                     $name = $phpcsFile->findNext(T_STRING, $class);
 
                     if ($name


### PR DESCRIPTION
fixes an infinite loop which would occur when an interface
extends an improperly named interface ending with Exception as there's
no T_EXCEPTION token and the only way to sniff the correct naming of
an exception is to detect the classname when it's extending an exception.

nevertheless the incorrect naming of the extended class should raise an error in the extended class itself rather than in the class which is extending it

fixes #171