### PR TITLE
check for the presence of a scope closer

### DIFF
--- a/Symfony/Sniffs/Formatting/ReturnOrThrowSniff.php
+++ b/Symfony/Sniffs/Formatting/ReturnOrThrowSniff.php
@@ -95,6 +95,10 @@ class ReturnOrThrowSniff implements Sniff
 
         $scopeCloserLine = -1;
 
+        if (false === isset($tokens[$opener]['scope_closer'])) {
+            return;
+        }
+
         if ($opener) {
             $scopeCloserLine = $tokens[$tokens[$opener]['scope_closer']]['line'];
         }


### PR DESCRIPTION
fixes throwing an exception when inline control structures are used
this should be taken care of by the Generic.ControlStructures.InlineControlStructure
sniff so we can safely return

fixes #170