### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "escapestudios/symfony2-coding-standard",
     "type": "phpcodesniffer-standard",
     "description": "CodeSniffer ruleset for the Symfony 2+ coding standard",
-    "keywords": ["Symfony2", "Symfony", "coding standard", "phpcs"],
+    "keywords": ["Symfony2", "Symfony", "coding standard", "phpcs", "static analysis"],
     "homepage": "https://github.com/djoos/Symfony-coding-standard",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.