### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/Symfony/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/build.properties export-ignore
+/build.xml export-ignore
+/TESTING.md export-ignore
+/tests_bootstrap.php export-ignore


### PR DESCRIPTION
Hello,

This PR add `.gitattributes` with `export-ignore` in order to reduce vendor size

More info here:
https://php.watch/articles/composer-gitattributes#export-ignore