### PR TITLE
Fix MultiLineArrayCommaSniff for PHP 8.3

### DIFF
--- a/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -93,6 +93,11 @@ class MultiLineArrayCommaSniff implements Sniff
                     $closePtr,
                     $stackPtr
                 );
+
+                if ($lastCommaPtr === false) {
+                    return;
+                }
+
                 while ($lastCommaPtr < $closePtr -1) {
                     $lastCommaPtr++;
 


### PR DESCRIPTION
Hello, 

I got this following error by running `vendor/bin/phpcbf`:

```bash
PHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php on line 97 in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:623
Stack trace:
#0 /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php(97): PHP_CodeSniffer\Runner->handleErrors()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/File.php(519): Symfony\Sniffs\Arrays\MultiLineArrayCommaSniff->process()
#2 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Fixer.php(175): PHP_CodeSniffer\Files\LocalFile->process()
#4 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reports/Cbf.php(52): PHP_CodeSniffer\Fixer->fixFile()
#5 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reporter.php(285): PHP_CodeSniffer\Reports\Cbf->generateFileReport()
#6 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(706): PHP_CodeSniffer\Reporter->cacheFileReport()
#7 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(519): PHP_CodeSniffer\Runner->processFile()
#8 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#9 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#10 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#11 {main}
  thrown in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php on line 623

Fatal error: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php on line 97 in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:623
Stack trace:
#0 /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php(97): PHP_CodeSniffer\Runner->handleErrors()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/File.php(519): Symfony\Sniffs\Arrays\MultiLineArrayCommaSniff->process()
#2 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Fixer.php(175): PHP_CodeSniffer\Files\LocalFile->process()
#4 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reports/Cbf.php(52): PHP_CodeSniffer\Fixer->fixFile()
#5 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reporter.php(285): PHP_CodeSniffer\Reports\Cbf->generateFileReport()
#6 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(706): PHP_CodeSniffer\Reporter->cacheFileReport()
#7 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(519): PHP_CodeSniffer\Runner->processFile()
#8 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#9 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#10 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#11 {main}
  thrown in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php on line 623
PHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php on line 97 in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:623
Stack trace:
#0 /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php(97): PHP_CodeSniffer\Runner->handleErrors()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/File.php(519): Symfony\Sniffs\Arrays\MultiLineArrayCommaSniff->process()
#2 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Fixer.php(175): PHP_CodeSniffer\Files\LocalFile->process()
#4 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reports/Cbf.php(52): PHP_CodeSniffer\Fixer->fixFile()
#5 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reporter.php(285): PHP_CodeSniffer\Reports\Cbf->generateFileReport()
#6 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(706): PHP_CodeSniffer\Reporter->cacheFileReport()
#7 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(519): PHP_CodeSniffer\Runner->processFile()
#8 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#9 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#10 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#11 {main}
  thrown in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php on line 623

Fatal error: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Increment on type bool has no effect, this will change in the next major version of PHP in /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php on line 97 in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:623
Stack trace:
#0 /var/www/html/app/vendor/escapestudios/symfony2-coding-standard/Symfony/Sniffs/Arrays/MultiLineArrayCommaSniff.php(97): PHP_CodeSniffer\Runner->handleErrors()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/File.php(519): Symfony\Sniffs\Arrays\MultiLineArrayCommaSniff->process()
#2 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
#3 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Fixer.php(175): PHP_CodeSniffer\Files\LocalFile->process()
#4 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reports/Cbf.php(52): PHP_CodeSniffer\Fixer->fixFile()
#5 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Reporter.php(285): PHP_CodeSniffer\Reports\Cbf->generateFileReport()
#6 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(706): PHP_CodeSniffer\Reporter->cacheFileReport()
#7 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(519): PHP_CodeSniffer\Runner->processFile()
#8 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#9 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#10 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#11 {main}
  thrown in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php on line 623
PHP Fatal error:  Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: One or more child processes failed to run in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:561
Stack trace:
#0 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#2 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#3 {main}
  thrown in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php on line 561

Fatal error: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: One or more child processes failed to run in /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php:561
Stack trace:
#0 /var/www/html/app/vendor/squizlabs/php_codesniffer/src/Runner.php(215): PHP_CodeSniffer\Runner->run()
#1 /var/www/html/app/vendor/squizlabs/php_codesniffer/bin/phpcbf(14): PHP_CodeSniffer\Runner->runPHPCBF()
#2 /var/www/html/app/vendor/bin/phpcbf(119): include('...')
#3 {main}
```

This error appears because the line of code return a boolean or an integer and for PHP 8.3 its deprecaded to increase a boolean, so this early return fixes this issue.

```
/** @return false|int */
$lastCommaPtr = $phpcsFile->findPrevious(
     T_COMMA,
     $closePtr,
     $stackPtr
);
```