### PR TITLE
Remove usage of deprecated sniff

### DIFF
--- a/Symfony/ruleset.xml
+++ b/Symfony/ruleset.xml
@@ -23,7 +23,6 @@
             <property name="spacing" value="0" />
         </properties>
     </rule>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.PHP.LowerCaseConstant"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>


### PR DESCRIPTION
Remove usage of sniff deprecated in phpcs 3.12.1 to be removed in phpcs 4.0.0